### PR TITLE
Python 3 compatibility, new GET method (/admin/users/list/)

### DIFF
--- a/pydiscourse/client.py
+++ b/pydiscourse/client.py
@@ -80,6 +80,12 @@ class DiscourseClient(object):
         """
         return self._delete('/admin/users/{0}.json'.format(userid), **kwargs)
 
+    def users(self, filter=None, **kwargs):
+        if filter is None:
+            filter = 'active'
+    
+        return self._get('/admin/users/list/{0}.json'.format(filter), **kwargs)
+
     def private_messages(self, username=None, **kwargs):
         if username is None:
             username = self.api_username

--- a/pydiscourse/main.py
+++ b/pydiscourse/main.py
@@ -30,7 +30,7 @@ class DiscourseCmd(cmd.Cmd):
                 try:
                     return method(*args, **kwargs)
                 except DiscourseError as e:
-                    print e, e.response.text
+                    print (e, e.response.text)
                     return e.response
             return wrapper
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -111,3 +111,8 @@ class MiscellaneousTests(ClientBaseTestCase):
         r = self.client.categories()
         self.assertRequestCalled(request, 'GET', '/categories.json')
         self.assertEqual(r, request().json()['category_list']['categories'])
+        
+    def test_users(self, request):
+        prepare_response(request)
+        r = self.client.users()
+        self.assertRequestCalled(request, 'GET', '/admin/users/list/active.json')


### PR DESCRIPTION
Python 3.x requires parentheses around the arguments to print().
This shouldn't break compatibility with Python 2.4/2.6, but fixes a syntax error with Python 3.x.

I've also added a method for the /admin/users/list GET API, which is used to grab a list of all active/staff/blocked/etc users.