### PR TITLE
Updated `/category/name.json` to `/c/name.json`

### DIFF
--- a/pydiscourse/client.py
+++ b/pydiscourse/client.py
@@ -204,7 +204,7 @@ class DiscourseClient(object):
         if parent:
             name = u'{0}/{1}'.format(parent, name)
 
-        return self._get(u'/category/{0}.json'.format(name), **kwargs)
+        return self._get(u'/c/{0}.json'.format(name), **kwargs)
 
     def site_settings(self, **kwargs):
         for setting, value in kwargs.items():


### PR DESCRIPTION
According to https://docs.discourse.org/#tag/Categories%2Fpaths%2F~1c~1%7Bid%7D.json%2Fget, the endpoint is not (or at least no more) `/category/name.json` but `/c/name.json`